### PR TITLE
Fix loop in get_transactions

### DIFF
--- a/pytoniq/liteclient/client.py
+++ b/pytoniq/liteclient/client.py
@@ -611,6 +611,8 @@ class LiteClient:
             tr_result, block_ids = await self.raw_get_transactions(address, amount, from_lt, from_hash)
             result += tr_result
             from_lt, from_hash = result[-1].prev_trans_lt, result[-1].prev_trans_hash
+            if from_lt == 0:
+                break
         # assert len(result) == count, f'expected {count} transactions, got {len(result)}'
         return result
 


### PR DESCRIPTION
If count of transactions is less than 16 and requested more (for example 32), then transactions will be repeated in result:

```python
transactions = await client.get_transactions('EQAzbU4C377dJA1FJvqbIuD2TShqtJpxH-ghOO-Olds-elHP', count=32)
for i, t in enumerate(transactions):
    print(f'{i:3d} -> {datetime.fromtimestamp(t.now)}')
```

```
   0 -> 2023-10-05 00:12:18
   1 -> 2023-10-05 00:11:57
-> 2 -> 2023-10-05 00:12:18
-> 3 -> 2023-10-05 00:11:57
```

After patch:
```
   0 -> 2023-10-05 00:12:18
   1 -> 2023-10-05 00:11:57
```