### PR TITLE
Contract.update() bugfix

### DIFF
--- a/pytoniq/contract/contract.py
+++ b/pytoniq/contract/contract.py
@@ -87,7 +87,7 @@ class Contract:
         return await cls.from_state_init(provider=provider, workchain=workchain, state_init=state_init, **kwargs)
 
     async def update(self):
-        account, shard_account = await self.raw_get_account_state()
+        account, shard_account = await self.provider.raw_get_account_state(self.address)
         self.set_account_attributes(account, shard_account)
 
     async def raw_get_account_state(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pytoniq",
-    version="0.1.20",
+    version="0.1.21",
     author="Maksim Kurbatov",
     author_email="cyrbatoff@gmail.com",
     description="TON Blockchain SDK",


### PR DESCRIPTION
Small bugfix on contract update data.
`update()` method expects both `account` and `shard_account` but `self.raw_get_account_state()` provides only `account`