### PR TITLE
add py.typed type checkers support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,8 @@ setuptools.setup(
     ],
     extras_require={
         'tvm': ['pytvm>=0.0.11'],
-    }
+    },
+    package_data={
+        "": ["*py.typed"],
+    },
 )


### PR DESCRIPTION
This library is very well typed and annotated, but type checkers, e.g. mypy, can't use it because the library does not conform to PEP-561.

https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

Add py.typed file to the package installation so that type checkers know that the module is typed.