### PR TITLE
except asyncio.IncompleteReadError insteed of ConnectionError

### DIFF
--- a/pytoniq/liteclient/client.py
+++ b/pytoniq/liteclient/client.py
@@ -142,7 +142,7 @@ class LiteClient:
     async def receive(self, data_len: int) -> bytes:
         try:
             data = await self.reader.readexactly(data_len)
-        except ConnectionError:
+        except asyncio.IncompleteReadError:
             await self.close()
             raise
         return data


### PR DESCRIPTION
According to the [asyncio documentation](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamReader.readexactly), readexactly() will raise asyncio.IncompleteReadError, not ConnectionError.

If asyncio.IncompleteReadError is not caught, we will get "Task exception was never retrieved."