### PR TITLE
Refactor logging to use module-level logger

### DIFF
--- a/pytoniq/adnl/adnl.py
+++ b/pytoniq/adnl/adnl.py
@@ -21,7 +21,7 @@ class SocketProtocol(asyncio.DatagramProtocol):
         self._error = None
         self._packets = asyncio.Queue(10000)
         self.timeout = timeout
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
 
     def connection_made(self, transport: transports.DatagramTransport) -> None:
         super().connection_made(transport)
@@ -58,7 +58,7 @@ class Node(Server):
         self.transport = transport
         self.pinger: asyncio.Task = None
         self.connected = False
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
         self._lost_pings = 0
 
     async def connect(self):
@@ -125,7 +125,7 @@ class AdnlTransport:
         self.loop: asyncio.AbstractEventLoop = None
         self.timeout = kwargs.get('timeout', 10)
         self.listener: asyncio.Task = None
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__ + "." + self.__class__.__name__)
         self.tasks: typing.Dict[str, asyncio.Future] = {}
         self.query_handlers: typing.Dict[str, typing.Callable] = {}
         self.custom_handlers: typing.Dict[str, typing.Callable] = {}

--- a/pytoniq/liteclient/balancer.py
+++ b/pytoniq/liteclient/balancer.py
@@ -30,7 +30,7 @@ class LiteBalancer:
         self._total_req_num = {}  # {index: successful_requests_num}
         self._current_req_num = {}  # {index: current_waiting_requests_num}
 
-        self._logger = logging.getLogger(self.__class__.__name__)
+        self._logger = logging.getLogger(__name__)
 
         self.inited = False
         self.max_req_per_peer = 100

--- a/pytoniq/liteclient/client.py
+++ b/pytoniq/liteclient/client.py
@@ -68,7 +68,7 @@ class LiteClient:
         """########### init ###########"""
         self.tasks = {}
         self.inited = False
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger = logging.getLogger(__name__)
         self.timeout = timeout
 
         """########### sync ###########"""
@@ -1167,7 +1167,7 @@ class LiteClient:
         init_block['root_hash'] = base64.b64decode(init_block['root_hash']).hex()
         init_block = BlockIdExt.from_dict(init_block)
         if not trust_level and init_block not in (init_mainnet_blocks + init_testnet_blocks):
-            logging.getLogger(cls.__name__).warning(msg='unknown init block found! please, check its hash to trust it')
+            logging.getLogger(__name__).warning(msg='unknown init block found! please, check its hash to trust it')
 
         return cls(
             host=socket.inet_ntoa(struct.pack('>i', ls['ip'])),

--- a/pytoniq/liteclient/sync.py
+++ b/pytoniq/liteclient/sync.py
@@ -6,7 +6,7 @@ import typing
 from pytoniq_core.tl.block import BlockIdExt
 
 
-logger = logging.getLogger('sync')
+logger = logging.getLogger(__name__)
 
 
 async def sync(client, to_block: BlockIdExt, init_block: BlockIdExt):


### PR DESCRIPTION
Now logging uses full name, not just class names or constants