### PR TITLE
Added optional valid_until in wallet transfer parameter

### DIFF
--- a/pytoniq/contract/wallets/wallet.py
+++ b/pytoniq/contract/wallets/wallet.py
@@ -122,7 +122,7 @@ class BaseWallet(Wallet):
             .store_cell(signing_message) \
             .end_cell()
 
-    async def raw_transfer(self, msgs: typing.List[WalletMessage], seqno_from_get_meth: bool = True):
+    async def raw_transfer(self, msgs: typing.List[WalletMessage], seqno_from_get_meth: bool = True, valid_until: typing.Optional[int] = None):
         """
         :param msgs: list of WalletMessages. to create one call create_wallet_internal_message meth
         :param seqno_from_get_meth: if True LiteClient will request seqno get method and use it, otherwise seqno from contract data will be taken
@@ -135,16 +135,16 @@ class BaseWallet(Wallet):
             seqno = await self.get_seqno()
         else:
             seqno = self.seqno
-        transfer_msg = self.raw_create_transfer_msg(private_key=self.private_key, seqno=seqno, wallet_id=self.wallet_id, messages=msgs)
+        transfer_msg = self.raw_create_transfer_msg(private_key=self.private_key, seqno=seqno, wallet_id=self.wallet_id, messages=msgs, valid_until=valid_until)
 
         return await self.send_external(body=transfer_msg)
 
     async def transfer(self, destination: typing.Union[Address, str], amount: int, body: Cell = Cell.empty(),
-                       state_init: StateInit = None):
+                       state_init: StateInit = None, valid_until: typing.Optional[int] = None):
         if isinstance(destination, str):
             destination = Address(destination)
         wallet_message = self.create_wallet_internal_message(destination=destination, value=amount, body=body, state_init=state_init)
-        return await self.raw_transfer(msgs=[wallet_message])
+        return await self.raw_transfer(msgs=[wallet_message], valid_until=valid_until)
 
     async def send_init_external(self):
         if not self.state_init:


### PR DESCRIPTION
I had trouble transferring funds to a contract with the error below:
```
message='LITE_SERVER_UNKNOWN: cannot apply external message to current state : External message was not accepted\nCannot run message on account: inbound external message rejected by transaction D236A1DF61696F5B2A6A3CFA5920B97273AF5E741492ED6C4F4292F1129EF941:\nexitcode=36, steps=13, gas_used=0\nVM Log (truncated):\n...CTPUSHCONST 19 (xC_,1)\nexecute DICTIGETJMPZ\nexecute PUSHPOW2 9\nexecute LDSLICEX\nexecute DUP\nexecute LDU 32\nexecute LDU 32\nexecute LDU 32\nexecute XCHG s2\nexecute NOW\nexecute LEQ\nexecute THROWIF 36\ndefault exception handler, terminating vm with exit code 36\n', url=URL('https://testnet.toncenter.com/api/v3/message')
```
I noticed that I needed to define a longer validity period for the contract and the transfer wallet function is not possible to define `valid_until`